### PR TITLE
Correct names for migrated apps

### DIFF
--- a/bin/verify_migrated_apps
+++ b/bin/verify_migrated_apps
@@ -3,10 +3,10 @@
 require_relative '../lib/tagging_sync_verifier'
 
 MIGRATED_APPS = %w[
-  business-support-finder
+  businesssupportfinder
   calculators
   calendars
-  licence-finder
+  licencefinder
   smartanswers
 ]
 


### PR DESCRIPTION
These migrated app names don't have hyphens.
