### PR TITLE
Fix bug with checking multiple apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # tagging-migration-verifier
+
+Tagging migration verifier is a script that checks our progress in migrating to the new tagging infrastructure.
+
+It compares tags in contentapi to content-store, to make sure the two are kept in sync.
+
+## Running the script
+The script will check the dev environment if GOVUK_APP_DOMAIN is not set.
+
+In tasks run by Jenkins, GOVUK_APP_DOMAIN will be available and point to the preview/staging/production domains.
+
+Run the script with
+
+    bundle exec bin/verify_migrated_apps

--- a/lib/tagging_sync_verifier.rb
+++ b/lib/tagging_sync_verifier.rb
@@ -17,7 +17,6 @@ class TaggingSyncVerifier
 
     if comparison.same?
       puts "Taggings for #{app_name} are in sync!"
-      exit(0)
     else
       puts "Taggings for #{app_name} are not in sync!"
       puts comparison.diffs


### PR DESCRIPTION
Removes and unwanted exit(0) that was stopping the script after the
first successful app.  We should only short circuit on failure.

Added a bit of context to the README.
