### PR TITLE
Use http library for fetching data

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 
 gem 'rspec'
+gem 'http'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,19 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.4.0)
     diff-lcs (1.2.5)
+    domain_name (0.5.20160128)
+      unf (>= 0.0.5, < 1.0.0)
+    http (1.0.2)
+      addressable (~> 2.3)
+      http-cookie (~> 1.0)
+      http-form_data (~> 1.0.1)
+      http_parser.rb (~> 0.6.0)
+    http-cookie (1.0.2)
+      domain_name (~> 0.5)
+    http-form_data (1.0.1)
+    http_parser.rb (0.6.0)
     rspec (3.4.0)
       rspec-core (~> 3.4.0)
       rspec-expectations (~> 3.4.0)
@@ -15,11 +27,15 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.4.0)
     rspec-support (3.4.1)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  http
   rspec
 
 BUNDLED WITH

--- a/lib/download.rb
+++ b/lib/download.rb
@@ -1,3 +1,5 @@
+require 'http'
+
 class Download
   def self.taggings_from(service, app_name)
     # In tasks run by Jenkins, GOVUK_APP_DOMAIN will be available and point to the
@@ -9,9 +11,14 @@ class Download
     end
 
     url = "#{host}/debug/taggings-per-app.json?app=#{app_name}"
-    JSON.parse(`curl -s #{url}`)
-  rescue JSON::ParserError
-    puts "Error running the verifier. Probably a connection error occured."
-    exit(1)
+    response = HTTP.get(url)
+    unless response.code == 200
+      puts "Error GET #{url}"
+      puts "#{response.inspect}"
+      puts "#{response}"
+      exit(1)
+    end
+
+    JSON.parse(response.body)
   end
 end


### PR DESCRIPTION
We currently use `curl` to fetch the data, so that we don't have to rely on gems being present (the jenkins job doesn't do `bundle install` yet - https://github.com/alphagov/govuk-puppet/pull/4098 does that).

By using a proper library we can more easily debug errors.

Trello: https://trello.com/c/q5jUopvT
