### PR TITLE
Add retry for download of taggings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 
 gem 'rspec'
-gem 'http'
+gem 'restclient', '~> 0.11.3'
+gem 'retries', '~> 0.0.5'
 gem 'awesome_print'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,20 +1,12 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.4.0)
     awesome_print (1.6.1)
     diff-lcs (1.2.5)
-    domain_name (0.5.20160128)
-      unf (>= 0.0.5, < 1.0.0)
-    http (1.0.2)
-      addressable (~> 2.3)
-      http-cookie (~> 1.0)
-      http-form_data (~> 1.0.1)
-      http_parser.rb (~> 0.6.0)
-    http-cookie (1.0.2)
-      domain_name (~> 0.5)
-    http-form_data (1.0.1)
-    http_parser.rb (0.6.0)
+    paint (1.0.1)
+    restclient (0.11.3)
+      paint (~> 1.0)
+    retries (0.0.5)
     rspec (3.4.0)
       rspec-core (~> 3.4.0)
       rspec-expectations (~> 3.4.0)
@@ -28,17 +20,15 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.4.0)
     rspec-support (3.4.1)
-    unf (0.1.4)
-      unf_ext
-    unf_ext (0.0.7.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   awesome_print
-  http
+  restclient (~> 0.11.3)
+  retries (~> 0.0.5)
   rspec
 
 BUNDLED WITH
-   1.10.6
+   1.11.2


### PR DESCRIPTION
The script will currently fail when it encounters an error. This includes temporary errors like `504 Gateway Timeout`, which happens frequently. This commit adds a retry system, so that the script will
attempt to download the taggings 10 times before giving up. It utilises an exponential backoff system. The attempts look like this:

```
2016-02-17 12:39:40 +0000 Downloading
http://contentapi.dev.gov.uk/debug/taggings-per-app.json?app=businesssupportfinder, attempt 1/10
2016-02-17 12:39:40 +0000 Downloading
http://contentapi.dev.gov.uk/debug/taggings-per-app.json?app=businesssupportfinder, attempt 2/10
2016-02-17 12:39:41 +0000 Downloading
http://contentapi.dev.gov.uk/debug/taggings-per-app.json?app=businesssupportfinder, attempt 3/10
2016-02-17 12:39:43 +0000 Downloading
http://contentapi.dev.gov.uk/debug/taggings-per-app.json?app=businesssupportfinder, attempt 4/10
2016-02-17 12:39:46 +0000 Downloading
http://contentapi.dev.gov.uk/debug/taggings-per-app.json?app=businesssupportfinder, attempt 5/10
2016-02-17 12:39:50 +0000 Downloading
http://contentapi.dev.gov.uk/debug/taggings-per-app.json?app=businesssupportfinder, attempt 6/10
2016-02-17 12:39:57 +0000 Downloading
http://contentapi.dev.gov.uk/debug/taggings-per-app.json?app=businesssupportfinder, attempt 7/10
2016-02-17 12:40:06 +0000 Downloading
http://contentapi.dev.gov.uk/debug/taggings-per-app.json?app=businesssupportfinder, attempt 8/10
2016-02-17 12:40:15 +0000 Downloading
http://contentapi.dev.gov.uk/debug/taggings-per-app.json?app=businesssupportfinder, attempt 9/10
2016-02-17 12:40:23 +0000 Downloading
http://contentapi.dev.gov.uk/debug/taggings-per-app.json?app=businesssupportfinder, attempt 10/10
```

This means the remote service has about a minute to recover before this script gives up.

Trello: https://trello.com/c/q5jUopvT
