### PR TITLE
Use rest-client, not restclient

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
 gem 'rspec'
-gem 'restclient', '~> 0.11.3'
+gem 'rest-client', '~> 1.8'
 gem 'retries', '~> 0.0.5'
 gem 'awesome_print'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,9 +3,16 @@ GEM
   specs:
     awesome_print (1.6.1)
     diff-lcs (1.2.5)
-    paint (1.0.1)
-    restclient (0.11.3)
-      paint (~> 1.0)
+    domain_name (0.5.20160128)
+      unf (>= 0.0.5, < 1.0.0)
+    http-cookie (1.0.2)
+      domain_name (~> 0.5)
+    mime-types (2.99)
+    netrc (0.11.0)
+    rest-client (1.8.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 3.0)
+      netrc (~> 0.7)
     retries (0.0.5)
     rspec (3.4.0)
       rspec-core (~> 3.4.0)
@@ -20,13 +27,16 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.4.0)
     rspec-support (3.4.1)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   awesome_print
-  restclient (~> 0.11.3)
+  rest-client (~> 1.8)
   retries (~> 0.0.5)
   rspec
 


### PR DESCRIPTION
We require the gem `restclient`, which is not the `rest-client` we want. This worked on my machine because I didn't use `bundle exec`.
