### PR TITLE
Add travel-advice-publisher to verify list

### DIFF
--- a/bin/verify_migrated_apps
+++ b/bin/verify_migrated_apps
@@ -8,6 +8,7 @@ MIGRATED_APPS = %w[
   calendars
   licencefinder
   smartanswers
+  travel-advice-publisher
 ]
 
 MIGRATED_APPS.each do |app_name|


### PR DESCRIPTION
This will make the tagging migration check start verifying that contentapi and publishing-api have the same tags.
