### PR TITLE
[See other PRs] Add tariff

### DIFF
--- a/bin/verify_migrated_apps
+++ b/bin/verify_migrated_apps
@@ -8,6 +8,7 @@ MIGRATED_APPS = %w[
   calendars
   licencefinder
   smartanswers
+  tariff
   travel-advice-publisher
 ]
 


### PR DESCRIPTION
Tariff tags have been migrated to the publishing platform.

Part of: https://trello.com/c/Aqvwgl1G/558-migrate-the-trade-tariff-page-to-new-tagging-infrastructure

Should be deployed with
- https://github.com/alphagov/panopticon/pull/333
- https://github.com/alphagov/rummager/pull/594
- https://github.com/alphagov/content-tagger/pull/50
